### PR TITLE
Add React Native calendar screen

### DIFF
--- a/mobile/apiClient.ts
+++ b/mobile/apiClient.ts
@@ -1,0 +1,32 @@
+export interface Task {
+  id: number;
+  title: string;
+  description?: string;
+  due_datetime?: string | null;
+  priority: 'low' | 'medium' | 'high';
+  status: string;
+  calendar_event_id?: string | null;
+}
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+}
+
+export async function fetchTasks(): Promise<Task[]> {
+  const r = await fetch('/api/v1/tasks');
+  if (!r.ok) {
+    throw new Error('Failed to fetch tasks');
+  }
+  return r.json();
+}
+
+export async function syncGoogleEvents(): Promise<CalendarEvent[]> {
+  const r = await fetch('/api/v1/google/sync');
+  if (!r.ok) {
+    throw new Error('Failed to fetch calendar events');
+  }
+  return r.json();
+}

--- a/mobile/screens/Home.tsx
+++ b/mobile/screens/Home.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { View, ScrollView, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import BigCalendar, { Event as CalendarEvent } from 'react-native-big-calendar';
+import { fetchTasks, syncGoogleEvents, Task } from '../apiClient';
+
+const priorityColors: Record<Task['priority'], string> = {
+  low: '#4caf50',
+  medium: '#ff9800',
+  high: '#f44336',
+};
+
+export default function Home() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [taskData, eventData] = await Promise.all([
+          fetchTasks(),
+          syncGoogleEvents(),
+        ]);
+        setTasks(taskData);
+        const taskEvents: CalendarEvent[] = taskData.map(t => ({
+          title: t.title,
+          start: t.due_datetime ? new Date(t.due_datetime) : new Date(),
+          end: t.due_datetime ? new Date(t.due_datetime) : new Date(),
+          color: priorityColors[t.priority],
+        }));
+        const googleEvents: CalendarEvent[] = eventData.map(e => ({
+          title: e.title,
+          start: new Date(e.start),
+          end: new Date(e.end),
+        }));
+        setEvents([...taskEvents, ...googleEvents]);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.loader}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <BigCalendar events={events} height={400} />
+      <ScrollView style={styles.list}>
+        {tasks.map(task => (
+          <Text key={task.id} style={{ color: priorityColors[task.priority] }}>
+            {task.title}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  loader: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  list: {
+    padding: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add an API client for fetching tasks and calendar events
- add a Home screen that shows react-native-big-calendar and a task list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*